### PR TITLE
Ignore case

### DIFF
--- a/Mastersign.Expressions.Demo/MainForm.Designer.cs
+++ b/Mastersign.Expressions.Demo/MainForm.Designer.cs
@@ -40,8 +40,9 @@ namespace Mastersign.Expressions.Demo
             this.timer = new System.Windows.Forms.Timer(this.components);
             this.cmbExpr = new System.Windows.Forms.ComboBox();
             this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-            this.display = new Mastersign.Expressions.Demo.Display();
             this.chkParallel = new System.Windows.Forms.CheckBox();
+            this.chkIgnoreCase = new System.Windows.Forms.CheckBox();
+            this.display = new Mastersign.Expressions.Demo.Display();
             this.SuspendLayout();
             // 
             // lblHints
@@ -49,9 +50,9 @@ namespace Mastersign.Expressions.Demo
             this.lblHints.AutoSize = true;
             this.lblHints.Location = new System.Drawing.Point(12, 9);
             this.lblHints.Name = "lblHints";
-            this.lblHints.Size = new System.Drawing.Size(151, 13);
+            this.lblHints.Size = new System.Drawing.Size(160, 13);
             this.lblHints.TabIndex = 1;
-            this.lblHints.Text = "Variables: W, H, X, Y, x, y, T, t";
+            this.lblHints.Text = "Variables: W, H, X, Y, rx, ry, T, rt";
             this.toolTip.SetToolTip(this.lblHints, resources.GetString("lblHints.ToolTip"));
             // 
             // lblMessage
@@ -75,12 +76,12 @@ namespace Mastersign.Expressions.Demo
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cmbExpr.FormattingEnabled = true;
             this.cmbExpr.Items.AddRange(new object[] {
-            "sin((x + t) * pi * 3) * sin((y - t) * pi * 3) * 0.5 + 0.5",
-            "cos((sqrt(x^2 + y^2) + t) * pi * 4) * 0.5 + 0.5",
-            "sin(t * pi * 10) * 0.5 + 0.5",
+            "sin((rx + rt) * pi * 3) * sin((ry - rt) * pi * 3) * 0.5 + 0.5",
+            "cos((sqrt(rx^2 + ry^2) + rt) * pi * 4) * 0.5 + 0.5",
+            "sin(rt * pi * 10) * 0.5 + 0.5",
             "rand()",
             "if(X = 100 or Y = 100, 1, 0)",
-            "if(sqrt(x^2 + y^2) > 0.3, 1, 0)",
+            "if(sqrt(rx^2 + ry^2) > 0.3, 1, 0)",
             "if(mod(X + Y + (T / 50), 50) = 0 or mod(X - Y - (T / 50), 50) = 0, sin(pi * mod(T" +
                 "/500f, 2f)) * 0.5 + 0.5, sin(pi * mod(T/2000f, 2f)) * 0.5 + 0.5)"});
             this.cmbExpr.Location = new System.Drawing.Point(12, 27);
@@ -88,6 +89,29 @@ namespace Mastersign.Expressions.Demo
             this.cmbExpr.Size = new System.Drawing.Size(513, 21);
             this.cmbExpr.TabIndex = 4;
             this.cmbExpr.TextChanged += new System.EventHandler(this.cmbExpr_TextChanged);
+            // 
+            // chkParallel
+            // 
+            this.chkParallel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkParallel.AutoSize = true;
+            this.chkParallel.Location = new System.Drawing.Point(446, 8);
+            this.chkParallel.Name = "chkParallel";
+            this.chkParallel.Size = new System.Drawing.Size(78, 17);
+            this.chkParallel.TabIndex = 6;
+            this.chkParallel.Text = "Multithread";
+            this.chkParallel.UseVisualStyleBackColor = true;
+            // 
+            // chkIgnoreCase
+            // 
+            this.chkIgnoreCase.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkIgnoreCase.AutoSize = true;
+            this.chkIgnoreCase.Location = new System.Drawing.Point(357, 8);
+            this.chkIgnoreCase.Name = "chkIgnoreCase";
+            this.chkIgnoreCase.Size = new System.Drawing.Size(83, 17);
+            this.chkIgnoreCase.TabIndex = 7;
+            this.chkIgnoreCase.Text = "Ignore Case";
+            this.chkIgnoreCase.UseVisualStyleBackColor = true;
+            this.chkIgnoreCase.CheckedChanged += new System.EventHandler(this.chkIgnoreCase_CheckedChanged);
             // 
             // display
             // 
@@ -102,22 +126,12 @@ namespace Mastersign.Expressions.Demo
             this.display.TabIndex = 5;
             this.display.Resize += new System.EventHandler(this.display_SizeChanged);
             // 
-            // chkParallel
-            // 
-            this.chkParallel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkParallel.AutoSize = true;
-            this.chkParallel.Location = new System.Drawing.Point(446, 8);
-            this.chkParallel.Name = "chkParallel";
-            this.chkParallel.Size = new System.Drawing.Size(78, 17);
-            this.chkParallel.TabIndex = 6;
-            this.chkParallel.Text = "Multithread";
-            this.chkParallel.UseVisualStyleBackColor = true;
-            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(537, 620);
+            this.Controls.Add(this.chkIgnoreCase);
             this.Controls.Add(this.chkParallel);
             this.Controls.Add(this.display);
             this.Controls.Add(this.cmbExpr);
@@ -139,6 +153,7 @@ namespace Mastersign.Expressions.Demo
         private Display display;
         private System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.CheckBox chkParallel;
+        private System.Windows.Forms.CheckBox chkIgnoreCase;
     }
 }
 

--- a/Mastersign.Expressions.Demo/MainForm.cs
+++ b/Mastersign.Expressions.Demo/MainForm.cs
@@ -14,7 +14,7 @@ namespace Mastersign.Expressions.Demo
 {
     public partial class MainForm : Form
     {
-        private readonly EvaluationContext evalContext = new EvaluationContext(EvaluationContext.Default);
+        private readonly EvaluationContext evalContext = new EvaluationContext();
         private Func<int, int, double, double, double> f;
 
         private ColorPalette bwPalette;
@@ -26,11 +26,12 @@ namespace Mastersign.Expressions.Demo
         {
             InitializeComponent();
             InitializeBackbuffer();
+            evalContext.LoadAllPackages();
             evalContext.SetParameters(
                 new ParameterInfo("X", typeof(int)),
                 new ParameterInfo("Y", typeof(int)),
-                new ParameterInfo("x", typeof(double)),
-                new ParameterInfo("y", typeof(double)));
+                new ParameterInfo("rx", typeof(double)),
+                new ParameterInfo("ry", typeof(double)));
             watch.Start();
             UpdateContext();
             CompileFunction();
@@ -43,6 +44,12 @@ namespace Mastersign.Expressions.Demo
         }
 
         private void cmbExpr_TextChanged(object sender, EventArgs e)
+        {
+            CompileFunction();
+            RepaintCanvas();
+        }
+
+        private void chkIgnoreCase_CheckedChanged(object sender, EventArgs e)
         {
             CompileFunction();
             RepaintCanvas();
@@ -85,6 +92,7 @@ namespace Mastersign.Expressions.Demo
                 cmbExpr.BackColor = SystemColors.Window;
                 expr = "0";
             }
+            evalContext.SetIgnoreCase(chkIgnoreCase.Checked);
             try
             {
                 f = evalContext.CompileExpression<int, int, double, double, double>(expr);
@@ -112,7 +120,7 @@ namespace Mastersign.Expressions.Demo
             var t = Environment.TickCount;
             evalContext.SetVariable("T", t);
             var phase = (t % 10000) / 10000.0;
-            evalContext.SetVariable("t", phase);
+            evalContext.SetVariable("rt", phase);
         }
 
         private void RepaintCanvas()

--- a/Mastersign.Expressions.Demo/MainForm.resx
+++ b/Mastersign.Expressions.Demo/MainForm.resx
@@ -125,10 +125,10 @@
 H: height in pixels
 X: position in pixels
 Y: position in pixels
-x: position in range of -0.5 ... +0.5
-y: position in range of -0.5 ... +0.5
+rx: position in range of -0.5 ... +0.5
+ry: position in range of -0.5 ... +0.5
 T: time in milliseconds
-t: periodic time in range of 0.0 ... 1.0</value>
+rt: periodic time in range of 0.0 ... 1.0</value>
   </data>
   <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>

--- a/Mastersign.Expressions.Tests/Language/LanguageTest.cs
+++ b/Mastersign.Expressions.Tests/Language/LanguageTest.cs
@@ -162,42 +162,80 @@ namespace Mastersign.Expressions.Tests.Language
         [Test]
         public void OperatorTest()
         {
-            ExpectReject(Grammar.AnyOperator,
+            var grammar = new Grammar();
+            ExpectReject(grammar.AnyOperator,
                 " ", "abc", "#", "==", "< >");
 
-            ExpectAccept(Grammar.AnyOperator,
+            ExpectAccept(grammar.AnyOperator,
                 "+", "-", " +", "+ ", "  +  ", "<>");
 
-            Assert.AreEqual(Operator.NumAddition, Parse(Grammar.AnyOperator, "+"));
-            Assert.AreEqual(Operator.NumSubtraction, Parse(Grammar.AnyOperator, "-"));
-            Assert.AreEqual(Operator.NumMultiplication, Parse(Grammar.AnyOperator, "*"));
-            Assert.AreEqual(Operator.NumDivision, Parse(Grammar.AnyOperator, "/"));
-            Assert.AreEqual(Operator.NumPower, Parse(Grammar.AnyOperator, "^"));
+            Assert.AreEqual(Operator.NumAddition, Parse(grammar.AnyOperator, "+"));
+            Assert.AreEqual(Operator.NumSubtraction, Parse(grammar.AnyOperator, "-"));
+            Assert.AreEqual(Operator.NumMultiplication, Parse(grammar.AnyOperator, "*"));
+            Assert.AreEqual(Operator.NumDivision, Parse(grammar.AnyOperator, "/"));
+            Assert.AreEqual(Operator.NumPower, Parse(grammar.AnyOperator, "^"));
 
-            Assert.AreEqual(Operator.BoolAnd, Parse(Grammar.AnyOperator, "and"));
-            Assert.AreEqual(Operator.BoolOr, Parse(Grammar.AnyOperator, "or"));
-            Assert.AreEqual(Operator.BoolXor, Parse(Grammar.AnyOperator, "xor"));
+            Assert.AreEqual(Operator.BoolAnd, Parse(grammar.AnyOperator, "and"));
+            Assert.AreEqual(Operator.BoolOr, Parse(grammar.AnyOperator, "or"));
+            Assert.AreEqual(Operator.BoolXor, Parse(grammar.AnyOperator, "xor"));
 
-            Assert.AreEqual(Operator.StringConcat, Parse(Grammar.AnyOperator, "&"));
+            Assert.AreEqual(Operator.StringConcat, Parse(grammar.AnyOperator, "&"));
 
-            Assert.AreEqual(Operator.RelationLess, Parse(Grammar.AnyOperator, "<"));
-            Assert.AreEqual(Operator.RelationLessOrEqual, Parse(Grammar.AnyOperator, "<="));
-            Assert.AreEqual(Operator.RelationEqual, Parse(Grammar.AnyOperator, "="));
-            Assert.AreEqual(Operator.RelationUnequal, Parse(Grammar.AnyOperator, "<>"));
-            Assert.AreEqual(Operator.RelationGreaterOrEqual, Parse(Grammar.AnyOperator, ">="));
-            Assert.AreEqual(Operator.RelationGreater, Parse(Grammar.AnyOperator, ">"));
+            Assert.AreEqual(Operator.RelationLess, Parse(grammar.AnyOperator, "<"));
+            Assert.AreEqual(Operator.RelationLessOrEqual, Parse(grammar.AnyOperator, "<="));
+            Assert.AreEqual(Operator.RelationEqual, Parse(grammar.AnyOperator, "="));
+            Assert.AreEqual(Operator.RelationUnequal, Parse(grammar.AnyOperator, "<>"));
+            Assert.AreEqual(Operator.RelationGreaterOrEqual, Parse(grammar.AnyOperator, ">="));
+            Assert.AreEqual(Operator.RelationGreater, Parse(grammar.AnyOperator, ">"));
+        }
+
+        [Test]
+        public void OperatorCasingTest()
+        {
+            var grammar = new Grammar();
+            ExpectAccept(grammar.AnyOperator, "and", "or", "xor");
+            ExpectReject(grammar.AnyOperator, "And", "Or", "Xor");
+            ExpectReject(grammar.AnyOperator, "AND", "OR", "XOR");
+        }
+
+        [Test]
+        public void OperatorIgnoreCasingTest()
+        {
+            var grammar = new Grammar { IgnoreOperatorCase = true };
+            ExpectAccept(grammar.AnyOperator, "and", "or", "xor");
+            ExpectAccept(grammar.AnyOperator, "And", "Or", "Xor");
+            ExpectAccept(grammar.AnyOperator, "AND", "OR", "XOR");
         }
 
         [Test]
         public void NullLiteralTest()
         {
-            ExpectReject(Grammar.NullLiteral,
+            var grammar = new Grammar();
+            ExpectReject(grammar.NullLiteral,
                 " ", "n", "0", "NULL");
 
-            ExpectAccept(Grammar.NullLiteral,
+            ExpectAccept(grammar.NullLiteral,
                 "null", " null", "null ", "\tnull ");
 
             ExpectResult("null", typeof(object), null);
+        }
+
+        [Test]
+        public void NullLiteralCasingTest()
+        {
+            var grammar = new Grammar();
+            ExpectAccept(grammar.NullLiteral, "null");
+            ExpectReject(grammar.NullLiteral, "Null");
+            ExpectReject(grammar.NullLiteral, "NULL");
+        }
+
+        [Test]
+        public void NullLiteralIgnoreCasingTest()
+        {
+            var grammar = new Grammar { IgnoreLiteralCase = true };
+            ExpectAccept(grammar.NullLiteral, "null");
+            ExpectAccept(grammar.NullLiteral, "Null");
+            ExpectAccept(grammar.NullLiteral, "NULL");
         }
 
         [Test]
@@ -307,19 +345,38 @@ namespace Mastersign.Expressions.Tests.Language
         [Test]
         public void BooleanTest()
         {
-            ExpectReject(Grammar.BooleanLiteral,
+            var grammar = new Grammar();
+            ExpectReject(grammar.BooleanLiteral,
                 "", " ", "0", "1", "t", "f");
 
-            ExpectAccept(Grammar.BooleanLiteral,
+            ExpectAccept(grammar.BooleanLiteral,
                 "true", "false");
 
             var context = new EvaluationContext();
 
-            Assert.AreEqual(true, Parse(Grammar.BooleanLiteral, "true").GetValue(context));
-            Assert.AreEqual(false, Parse(Grammar.BooleanLiteral, "false").GetValue(context));
+            Assert.AreEqual(true, Parse(grammar.BooleanLiteral, "true").GetValue(context));
+            Assert.AreEqual(false, Parse(grammar.BooleanLiteral, "false").GetValue(context));
 
-            var res = Parse(Grammar.BooleanLiteral, "true");
+            var res = Parse(grammar.BooleanLiteral, "true");
             Assert.IsTrue(res.CheckSemantic(context, new StringBuilder()));
+        }
+
+        [Test]
+        public void BooleanCasingTest()
+        {
+            var grammar = new Grammar();
+            ExpectAccept(grammar.BooleanLiteral, "true", "false");
+            ExpectReject(grammar.BooleanLiteral, "True", "False");
+            ExpectReject(grammar.BooleanLiteral, "TRUE", "FALSE");
+        }
+
+        [Test]
+        public void BooleanIgnoreCasingTest()
+        {
+            var grammar = new Grammar { IgnoreLiteralCase = true };
+            ExpectAccept(grammar.BooleanLiteral, "true", "false");
+            ExpectAccept(grammar.BooleanLiteral, "True", "False");
+            ExpectAccept(grammar.BooleanLiteral, "TRUE", "FALSE");
         }
 
         [Test]
@@ -596,6 +653,49 @@ namespace Mastersign.Expressions.Tests.Language
         }
 
         [Test]
+        public void ParameterCasingTest()
+        {
+            var context = new EvaluationContext();
+            context.SetParameters(
+                new ParameterInfo("a", typeof(int)),
+                new ParameterInfo("B", typeof(string)));
+
+            var fA = context.CompileExpression<int, string, int>("a");
+            Assert.AreEqual(42, fA(42, "test"));
+
+            var fB = context.CompileExpression<int, string, string>("B");
+            Assert.AreEqual("test", fB(42, "test"));
+
+            Assert.Throws(typeof(SemanticErrorException), () =>
+            {
+                context.CompileExpression("A");
+            });
+            Assert.Throws(typeof(SemanticErrorException), () =>
+            {
+                context.CompileExpression("b");
+            });
+        }
+
+        [Test]
+        public void ParameterIgnoreCasingText()
+        {
+            var context = new EvaluationContext { IgnoreParameterNameCase = true };
+            context.SetParameters(
+                new ParameterInfo("a", typeof(int)),
+                new ParameterInfo("B", typeof(string)));
+
+            var fA1 = context.CompileExpression<int, string, int>("a");
+            Assert.AreEqual(42, fA1(42, "test"));
+            var fA2 = context.CompileExpression<int, string, int>("A");
+            Assert.AreEqual(42, fA2(42, "test"));
+
+            var fB1 = context.CompileExpression<int, string, string>("B");
+            Assert.AreEqual("test", fB1(42, "test"));
+            var fB2 = context.CompileExpression<int, string, string>("b");
+            Assert.AreEqual("test", fB2(42, "test"));
+        }
+
+        [Test]
         public void ExpressionTest()
         {
             var context = new EvaluationContext();
@@ -679,13 +779,13 @@ namespace Mastersign.Expressions.Tests.Language
 
             var context = new EvaluationContext();
             context.SetVariable("π", Math.PI);
-            context.SetVariable("wrappedString", new WrappedString("Hello!"));
+            //context.SetVariable("wrappedString", new WrappedString("Hello!"));
             context.AddFunction("sin", new FunctionHandle((Func<double, double>)Math.Sin));
-            //context.AddFunction("x2", new FunctionHandle((Func<decimal, decimal>)(v => v * 2m)));
             context.AddFunction("min", new FunctionHandle((Func<int, int, int>)Math.Min));
             context.AddFunction("min", new FunctionHandle((Func<string, string, string>)Strings.Min));
+            //context.AddFunction("x2", new FunctionHandle((Func<decimal, decimal>)(v => v * 2m)));
             //context.AddFunction("rev", new FunctionHandle((Func<string, string>)(s => new string(s.Reverse().ToArray()))));
-            //context.AddFunction("if", new FunctionHandle(GetType().GetMethod("If")));
+            //context.AddFunction("test_if", new FunctionHandle(GetType().GetMethod("If")));
 
             ExpectResult(context, "sin(π)", typeof(double), Math.Sin(Math.PI)); // complete match
             ExpectResult(context, "min(100, 42)", typeof(int), Math.Min(100, 42));
@@ -694,13 +794,63 @@ namespace Mastersign.Expressions.Tests.Language
 
             //ExpectResult(context, "x2(4)", typeof(decimal), 4 * 2m); // implicit numeric cast from int to decimal
             //ExpectResult(context, "rev(wrappedString)", typeof(string), new string("implicit(Hello!)".Reverse().ToArray())); // overloaded implicit cast operator
-            //ExpectResult(context, "if(4 < 5, \"Yes\", \"No\")", typeof (string), "Yes"); // generic method binding
+            //ExpectResult(context, "test_if(4 < 5, \"Yes\", \"No\")", typeof (string), "Yes"); // generic method binding
 
             ExpectError(context, "foo(π)"); // not existing function
 
             ExpectError(context, "sin(true)"); // wrong parameter type
             ExpectError(context, "sin()"); // too few parameter
             ExpectError(context, "sin(pi, 2)"); // too many parameter
+        }
+
+        [Test]
+        public void FunctionCasingTest()
+        {
+            var context = new EvaluationContext();
+            context.AddFunction("test", new FunctionHandle((Func<int, int>)(a => a * 2)));
+            context.AddFunction("Test", new FunctionHandle((Func<int, int>)(a => a * 3)));
+            context.AddFunction("TEST", new FunctionHandle((Func<int, int>)(a => a * 4)));
+
+            ExpectResult(context, "test(10)", typeof(int), 20);
+            ExpectResult(context, "Test(10)", typeof(int), 30);
+            ExpectResult(context, "TEST(10)", typeof(int), 40);
+            ExpectError(context, "tESt(10)");
+        }
+
+        [Test]
+        public void FunctionIgnoreCasingTest()
+        {
+            var context = new EvaluationContext { IgnoreFunctionNameCase = true };
+            context.AddFunction("test", new FunctionHandle((Func<int, int>)(a => a * 2)));
+
+            ExpectResult(context, "test(10)", typeof(int), 20);
+            ExpectResult(context, "Test(10)", typeof(int), 20);
+            ExpectResult(context, "TEST(10)", typeof(int), 20);
+            ExpectResult(context, "tESt(10)", typeof(int), 20);
+        }
+
+        [Test]
+        public void FunctionLateIgnoreCasingTest()
+        {
+            var context = new EvaluationContext();
+            context.AddFunction("test", new FunctionHandle((Func<int, int>)(a => a * 2)));
+
+            context.IgnoreFunctionNameCase = true;
+
+            ExpectResult(context, "test(10)", typeof(int), 20);
+            ExpectResult(context, "Test(10)", typeof(int), 20);
+            ExpectResult(context, "TEST(10)", typeof(int), 20);
+            ExpectResult(context, "tESt(10)", typeof(int), 20);
+        }
+
+        [Test]
+        public void AmbigousFunctionTest()
+        {
+            var context = new EvaluationContext();
+            context.AddFunction("twice", new FunctionHandle((Func<string>)(() => "One")));
+            context.AddFunction("twice", new FunctionHandle((Func<string>)(() => "Two")));
+
+            ExpectError("twice()");
         }
 
         [Test]
@@ -732,6 +882,22 @@ namespace Mastersign.Expressions.Tests.Language
             // wrapped semantic errors
             ExpectError(context, Conditional.FUNCTION_NAME + "(not_exist(), a, b)"); // invalid function call as parameter
             ExpectError(context, Conditional.FUNCTION_NAME + "(true, not_exist(), x)"); // invalid function call as parameter
+        }
+
+        [Test]
+        public void ConditionalCasingTest()
+        {
+            var context = new EvaluationContext();
+            ExpectResult(context, Conditional.FUNCTION_NAME + "(true, 1, 2)", typeof(int), 1);
+            ExpectError(context, Conditional.FUNCTION_NAME.ToUpperInvariant() + "(true, 1, 2)");
+        }
+
+        [Test]
+        public void ConditionalIgnoreCasingTest()
+        {
+            var context = new EvaluationContext { IgnoreFunctionNameCase = true };
+            ExpectResult(context, Conditional.FUNCTION_NAME + "(true, 1, 2)", typeof(int), 1);
+            ExpectResult(context, Conditional.FUNCTION_NAME.ToUpperInvariant() + "(true, 1, 2)", typeof(int), 1);
         }
 
         [Test]

--- a/Mastersign.Expressions/Language/FunctionCall.cs
+++ b/Mastersign.Expressions/Language/FunctionCall.cs
@@ -8,8 +8,9 @@ namespace Mastersign.Expressions.Language
 {
     internal class FunctionCall : ExpressionNode
     {
-        public static FunctionCall CreateInstance(string identifier)
+        public static FunctionCall CreateInstance(string identifier, bool ignoreCase)
         {
+            if (ignoreCase) identifier = identifier.ToLowerInvariant();
             switch (identifier)
             {
                 case Conditional.FUNCTION_NAME:


### PR DESCRIPTION
added properties on `EvaluationContext` to opt-in to ignoring the case of certain parts of the language: operators, literals, variables, parameters, function names.